### PR TITLE
🐛 GitHub Actionsのサンドボックスモード検出の修正

### DIFF
--- a/.github/workflows/gmail-to-line-notification.yml
+++ b/.github/workflows/gmail-to-line-notification.yml
@@ -37,9 +37,9 @@ jobs:
         id: gmail_check
         env:
           GOOGLE_OAUTH_TOKEN: ${{ secrets.GOOGLE_OAUTH_TOKEN }}
-          LINE_CHANNEL_ACCESS_TOKEN: ${{ (github.event_name == 'workflow_dispatch' && inputs.sandbox == 'true') && secrets.LINE_CHANNEL_ACCESS_TOKEN_SANDBOX || secrets.LINE_CHANNEL_ACCESS_TOKEN }}
-          LINE_USER_ID: ${{ (github.event_name == 'workflow_dispatch' && inputs.sandbox == 'true') && secrets.LINE_USER_ID_SANDBOX || secrets.LINE_USER_ID }}
-          SANDBOX_MODE: ${{ (github.event_name == 'workflow_dispatch' && inputs.sandbox == 'true') && 'true' || 'false' }}
+          LINE_CHANNEL_ACCESS_TOKEN: ${{ (github.event_name == 'workflow_dispatch' && inputs.sandbox == true) && secrets.LINE_CHANNEL_ACCESS_TOKEN_SANDBOX || secrets.LINE_CHANNEL_ACCESS_TOKEN }}
+          LINE_USER_ID: ${{ (github.event_name == 'workflow_dispatch' && inputs.sandbox == true) && secrets.LINE_USER_ID_SANDBOX || secrets.LINE_USER_ID }}
+          SANDBOX_MODE: ${{ (github.event_name == 'workflow_dispatch' && inputs.sandbox == true) && 'true' || 'false' }}
         run: uv run python -m src.gmail_notifier
 
       - name: Notify to Slack on failure


### PR DESCRIPTION

## 📒 変更概要

- GitHub Actionsのワークフローで、サンドボックスモードの検出に関する修正を行いました。

## ⚒ 技術的詳細

- `.github/workflows/gmail-to-line-notification.yml`ファイルにおいて、`inputs.sandbox`の値を文字列からブール値に変更しました。
  - 具体的には、`inputs.sandbox == 'true'`から`inputs.sandbox == true`に修正しました。
  - この変更により、サンドボックスモードの判定が正しく行われるようになります。

## ⚠ 注意点

- 💡 この修正は、GitHub Actionsの`workflow_dispatch`イベントでサンドボックスモードを使用する際にのみ影響します。通常のワークフロー実行には影響しません。