### PR TITLE
🌟 Slack通知用の環境変数を追加

### DIFF
--- a/.github/workflows/gmail-to-line-notification.yml
+++ b/.github/workflows/gmail-to-line-notification.yml
@@ -43,6 +43,8 @@ jobs:
           LINE_CHANNEL_ACCESS_TOKEN_SANDBOX: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN_SANDBOX }}
           LINE_USER_ID: ${{ secrets.LINE_USER_ID }}
           LINE_USER_ID_SANDBOX: ${{ secrets.LINE_USER_ID_SANDBOX }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SANDBOX_MODE: ${{ (github.event_name == 'workflow_dispatch' && inputs.sandbox == true) && 'true' || 'false' }}
         run: uv run python -m src.gmail_notifier
 


### PR DESCRIPTION

## 📒 変更概要

- `gmail-to-line-notification.yml`にSlack通知用の環境変数を追加しました。

## ⚒ 技術的詳細

- 以下の環境変数が追加されました。
  - `SLACK_BOT_TOKEN`: Slackのボットトークンを設定するための変数です。
  - `SLACK_CHANNEL_ID`: 通知を送信するSlackチャンネルのIDを設定するための変数です。

## ⚠ 注意点

- 💡 新たに追加された環境変数は、GitHub Secretsに設定されている必要があります。設定されていない場合、Slack通知が正常に動作しない可能性があります。